### PR TITLE
Small corrections to fix post-verification response

### DIFF
--- a/php/recaptchalib.php
+++ b/php/recaptchalib.php
@@ -107,7 +107,7 @@ class ReCaptcha
     public function verifyResponse($remoteIp, $response)
     {
         // Discard empty solution submissions
-        if ($response == null || strlen($response) == 0) {
+        if (empty($response)) {
             $recaptchaResponse = new ReCaptchaResponse();
             $recaptchaResponse->success = false;
             $recaptchaResponse->errorCodes = 'missing-input';

--- a/php/recaptchalib.php
+++ b/php/recaptchalib.php
@@ -126,11 +126,11 @@ class ReCaptcha
         $answers = json_decode($getResponse, true);
         $recaptchaResponse = new ReCaptchaResponse();
 
-        if (trim($answers ['success']) == true) {
+        if(isset($answers['success']) && trim($answers['success'])) {
             $recaptchaResponse->success = true;
         } else {
             $recaptchaResponse->success = false;
-            $recaptchaResponse->errorCodes = $answers [error-codes];
+            $recaptchaResponse->errorCodes = isset($answers['error-codes']) ? $answers['error-codes'] : null;
         }
 
         return $recaptchaResponse;

--- a/php/recaptchalib.php
+++ b/php/recaptchalib.php
@@ -70,14 +70,11 @@ class ReCaptcha
      */
     private function _encodeQS($data)
     {
-        $req = "";
+        $param = array();
         foreach ($data as $key => $value) {
-            $req .= $key . '=' . urlencode(stripslashes($value)) . '&';
+            $param[] = $key . '=' . rawurlencode(stripslashes(trim($value)));
         }
-
-        // Cut the last '&'
-        $req=substr($req, 0, strlen($req)-1);
-        return $req;
+        return implode('&', $param);
     }
 
     /**
@@ -90,8 +87,8 @@ class ReCaptcha
      */
     private function _submitHTTPGet($path, $data)
     {
-        $req = $this->_encodeQS($data);
-        $response = file_get_contents($path . $req);
+        $query = $this->_encodeQS($data);
+        $response = file_get_contents($path . $query);
         return $response;
     }
 

--- a/php/recaptchalib.php
+++ b/php/recaptchalib.php
@@ -42,8 +42,7 @@ class ReCaptchaResponse
 class ReCaptcha
 {
     private static $_signupUrl = "https://www.google.com/recaptcha/admin";
-    private static $_siteVerifyUrl =
-        "https://www.google.com/recaptcha/api/siteverify?";
+    private static $_siteVerifyUrl = "https://www.google.com/recaptcha/api/siteverify?";
     private $_secret;
     private static $_version = "php_1.0";
 
@@ -54,9 +53,8 @@ class ReCaptcha
      */
     function ReCaptcha($secret)
     {
-        if ($secret == null || $secret == "") {
-            die("To use reCAPTCHA you must get an API key from <a href='"
-                . self::$_signupUrl . "'>" . self::$_signupUrl . "</a>");
+        if (empty($secret)) {
+            die("To use reCAPTCHA you must get an API key from <a href='" . self::$_signupUrl . "'>" . self::$_signupUrl . "</a>");
         }
         $this->_secret=$secret;
     }


### PR DESCRIPTION
@slackero has provided a few key fixes to make `verifyResponse()` useable.

Changes:
- Improved response, "success", and "error-codes" handling.

Notes:
- 7b72063 will be disregarded as already addressed by d304196 (#1)
- b686350 will be disregarded in favour of c969a73 (#1)